### PR TITLE
inspect.ml: Fix syntax error in call to Ident.name

### DIFF
--- a/ocaml_debug_adapter/inspect.ml
+++ b/ocaml_debug_adapter/inspect.ml
@@ -525,7 +525,7 @@ module Make (Args : sig
       Ident.fold_name Ident.Map.add tbl Ident.Map.empty
       |> Ident.Map.bindings
       |> Lwt_list.filter_map_s (fun (ident, _) ->
-        let name = ident.Ident.name in
+        let name = Ident.name ident in
         match Env.lookup_value (Longident.Lident name) env with
         | exception Not_found -> Lwt.return_none
         | (_, valdesc) ->


### PR DESCRIPTION
This fixes an error that prevented the project from compiling. `ident.Ident.name` didn't make sense since it would imply accessing a record.