### PR TITLE
Fix %%VERSION%% interpolation

### DIFF
--- a/ocaml_debug_adapter/main.ml
+++ b/ocaml_debug_adapter/main.ml
@@ -42,5 +42,5 @@ let () =
   let doc = "make OCaml debugging less sucks" in
   Term.(exit @@ eval (
     const command $ server $ port,
-    info ~version:"%‌%VERSION%%" ~doc "ocamlearlybird"
+    info ~version:"%%VERSION%%" ~doc "ocamlearlybird"
   ))


### PR DESCRIPTION
`~version:"%<U+200C>%VERSION%%"` -> `~version:"%%VERSION%%"`