### PR TITLE
feat: add extension logging, improve extension features

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,16 +9,14 @@
       "type": "ocamlearlybird",
       "request": "launch",
       "program": "${workspaceFolder}/_build/default/src/main/main.bc",
-      "arguments": ["serve", "--port=4711", "--verbosity=debug"],
+      "arguments": [
+        "serve",
+        "--port=4711",
+        "--verbosity=debug"
+      ],
       "stopOnEntry": true,
       "yieldSteps": 4096,
       "onlyDebugGlob": "<${workspaceFolder}/**/*>"
-    },
-    {
-      "name": "Run Extension",
-      "type": "extensionHost",
-      "request": "launch",
-      "args": ["--extensionDevelopmentPath=${workspaceFolder}"]
-    },
+    }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,14 +9,16 @@
       "type": "ocamlearlybird",
       "request": "launch",
       "program": "${workspaceFolder}/_build/default/src/main/main.bc",
-      "arguments": [
-        "serve",
-        "--port=4711",
-        "--verbosity=debug"
-      ],
+      "arguments": ["serve", "--port=4711", "--verbosity=debug"],
       "stopOnEntry": true,
       "yieldSteps": 4096,
       "onlyDebugGlob": "<${workspaceFolder}/**/*>"
-    }
+    },
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"]
+    },
   ]
 }

--- a/integrations/vscode/.vscode/launch.json
+++ b/integrations/vscode/.vscode/launch.json
@@ -5,9 +5,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}"
-      ],
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
       "name": "Launch Extension",
       "request": "launch",
       "type": "pwa-extensionHost"

--- a/integrations/vscode/extension.js
+++ b/integrations/vscode/extension.js
@@ -1,145 +1,171 @@
 const vscode = require("vscode");
 const FS = require("fs");
 const Path = require("path");
-const CP = require("child_process");
-const Util = require("util");
 
-const SUPPORTED_MAGICS = ["Caml1999X028", "Caml1999X029"];
+const EXT_NAME = "ocamlearlybird";
 const MAGIC_LENGTH = SUPPORTED_MAGICS[0].length;
+const SUPPORTED_MAGICS = ["Caml1999X028", "Caml1999X029"];
 
 const log = (() => {
-  const logger = vscode.window.createOutputChannel();
-  return (text) => {
-    logger.appendLine(text);
+  const logger = vscode.window.createOutputChannel(EXT_NAME);
+  const logWithLevel = (level) => (text) => {
+    logger.appendLine(`${level}: ${text}`);
     logger.show();
+  };
+  return {
+    info: logWithLevel("info"),
+    error: logWithLevel("error"),
   };
 })();
 
 const isBytecodeFile = async (path) => {
+  const stat = await FS.promises.stat(path);
+  if (!stat.isFile()) return false;
+  const file = await FS.promises.open(path);
   try {
-    const stat = await FS.promises.stat(path);
-    const file = await FS.promises.open(path);
-    try {
-      const buffer = Buffer.alloc(MAGIC_LENGTH);
-      await file.read(buffer, 0, MAGIC_LENGTH, stat.size - MAGIC_LENGTH);
-      const magic = buffer.toString("ascii");
-      return SUPPORTED_MAGICS.includes(magic);
-    } finally {
-      file.close();
-    }
-  } catch {
-    return false;
+    const buffer = Buffer.alloc(MAGIC_LENGTH);
+    await file.read(buffer, 0, MAGIC_LENGTH, stat.size - MAGIC_LENGTH);
+    const magic = buffer.toString("ascii");
+    return SUPPORTED_MAGICS.includes(magic);
+  } finally {
+    file.close();
   }
 };
 
-const debugConfigProvider = {
-  async provideDebugConfigurations(folder, token) {
-    return [
-      {
-        name: "OCaml Debug",
-        type: "ocamlearlybird",
-        request: "launch",
-        program: "${workspaceFolder}/a.out",
-        stopOnEntry: false,
-        yieldSteps: 4096,
-        onlyDebugGlob: "<${workspaceFolder}/**/*>",
-      },
-    ];
-  },
-  async resolveDebugConfiguration(folder, config, token) {
-    if (!config.type) {
-      config = {
-        name: "${fileBasename}",
-        type: "ocamlearlybird",
-        request: "launch",
-        program: "${file}",
-      };
-    }
-    return config;
-  },
-  async resolveDebugConfigurationWithSubstitutedVariables(
-    folder,
-    config,
-    token
-  ) {
-    if (!(await isBytecodeFile(config.program))) {
-      vscode.window.showErrorMessage("Unsupported file format");
-      return;
-    }
-    return config;
-  },
-};
-
-const jsonStringifyReplacer = (k, v) =>
-  k ? (typeof v === "function" ? `function:${v.name || k}` : "function") : v;
-const jsonStringify = (str) => JSON.stringify(str, jsonStringifyReplacer, 2);
+const jsonStringifyFnSerializer = (k, v) =>
+  k ? (typeof v === "function" ? `[fn ${v.name || k}]` : v) : v;
+const asJson = (str) => JSON.stringify(str, jsonStringifyFnSerializer, 2);
 
 module.exports = {
   /**@param {vscode.ExtensionContext} context */
   activate(context) {
-    log(`activating`);
-    const config = vscode.workspace.getConfiguration("ocamlearlybird");
-    const serializedConfig = jsonStringify(config);
-    log(`configuration detected: ${serializedConfig}`);
-    const ocamlearlybirdPath = config.get("path");
-    context.subscriptions.push(
-      vscode.debug.registerDebugAdapterDescriptorFactory("ocamlearlybird", {
-        createDebugAdapterDescriptor(session, executable) {
-          log(`on:createDebugAdapterDescriptor`);
-          return new vscode.DebugAdapterExecutable(ocamlearlybirdPath, [
-            "debug",
-          ]);
-        },
-      })
-    );
-    context.subscriptions.push(
-      vscode.commands.registerCommand("ocamlearlybird.startDebug", async () => {
-        log(`on:ocamlearlybird.startDebug`);
-        const uri = vscode.window.activeTextEditor.document.uri;
-        const folder = vscode.workspace.getWorkspaceFolder();
-        await vscode.debug.startDebugging(folder, {
-          name: Path.basename(uri.fsPath),
-          type: "ocamlearlybird",
-          request: "launch",
-          stopOnEntry: true,
-          yieldSteps: 4096,
-          program: uri.fsPath,
-        });
-      })
-    );
-    context.subscriptions.push(
-      vscode.commands.registerCommand(
-        "ocamlearlybird.variableGotoClosureCodeLocation",
-        async (context) => {
-          log(`on:ocamlearlybird.variableGotoClosureCodeLocation`);
-          const result = await vscode.debug.activeDebugSession.customRequest(
-            "variableGetClosureCodeLocation",
-            { handle: context.variable.variablesReference }
-          );
-          if (result.location != null) {
-            const loc = result.location;
-            const doc = vscode.workspace.openTextDocument(
-              result.location.source
+    try {
+      log.info(`activating`);
+      const config = vscode.workspace.getConfiguration("ocamlearlybird");
+      const serializedConfig = asJson(config);
+      log.info(`configuration detected: ${serializedConfig}`);
+      const ocamlearlybirdPath = config.get("path");
+      context.subscriptions.push(
+        vscode.debug.registerDebugAdapterDescriptorFactory("ocamlearlybird", {
+          createDebugAdapterDescriptor(session, executable) {
+            log.info(
+              `on:createDebugAdapterDescriptor, ${asJson({
+                session,
+                executable,
+              })}`
             );
-            vscode.window.showTextDocument(doc, {
-              preview: true,
-              selection: new vscode.Range(
-                new vscode.Position(loc.pos[0] - 1, loc.pos[1] - 1),
-                new vscode.Position(loc.end_[0] - 1, loc.end_[1] - 1)
-              ),
-            });
-          } else {
-            vscode.window.showInformationMessage("No closure code location");
+            if (config.connectToLocalDebugAdapterServer) {
+              return new vscode.DebugAdapterServer(4711, "localhost");
+            }
+            return new vscode.DebugAdapterExecutable(ocamlearlybirdPath, [
+              "debug",
+            ]);
+          },
+        })
+      );
+      context.subscriptions.push(
+        vscode.commands.registerCommand(
+          "ocamlearlybird.startDebug",
+          async () => {
+            try {
+              log.info(`on:ocamlearlybird.startDebug`);
+              const uri = vscode.window.activeTextEditor.document.uri;
+              const folder = vscode.workspace.getWorkspaceFolder(uri);
+              if (!folder) {
+                throw new Error(
+                  `No active text editor document found to start debug session on`
+                );
+              }
+              const options = {
+                name: Path.basename(uri.fsPath),
+                type: "ocamlearlybird",
+                request: "launch",
+                stopOnEntry: true,
+                yieldSteps: 4096,
+                program: uri.fsPath,
+              };
+              log.file(
+                `debug session starting with: ${asJson(options)}`
+              );
+              await vscode.debug.startDebugging(folder, options);
+              log.info("debug session complete");
+            } catch (err) {
+              log.error(err);
+            }
           }
-        }
-      )
-    );
-    context.subscriptions.push(
-      vscode.debug.registerDebugConfigurationProvider(
-        "ocamlearlybird",
-        debugConfigProvider
-      )
-    );
+        )
+      );
+      context.subscriptions.push(
+        vscode.commands.registerCommand(
+          "ocamlearlybird.variableGotoClosureCodeLocation",
+          async (context) => {
+            log.info(`on:ocamlearlybird.variableGotoClosureCodeLocation`);
+            const result = await vscode.debug.activeDebugSession.customRequest(
+              "variableGetClosureCodeLocation",
+              { handle: context.variable.variablesReference }
+            );
+            if (result.location != null) {
+              const loc = result.location;
+              const doc = vscode.workspace.openTextDocument(
+                result.location.source
+              );
+              vscode.window.showTextDocument(doc, {
+                preview: true,
+                selection: new vscode.Range(
+                  new vscode.Position(loc.pos[0] - 1, loc.pos[1] - 1),
+                  new vscode.Position(loc.end_[0] - 1, loc.end_[1] - 1)
+                ),
+              });
+            } else {
+              vscode.window.showInformationMessage("No closure code location");
+            }
+          }
+        )
+      );
+      context.subscriptions.push(
+        vscode.debug.registerDebugConfigurationProvider("ocamlearlybird", {
+          async provideDebugConfigurations(folder, token) {
+            return [
+              {
+                name: "OCaml Debug",
+                type: "ocamlearlybird",
+                request: "launch",
+                program: "${workspaceFolder}/a.out",
+                stopOnEntry: false,
+                yieldSteps: 4096,
+                onlyDebugGlob: "<${workspaceFolder}/**/*>",
+              },
+            ];
+          },
+          async resolveDebugConfiguration(folder, config, token) {
+            if (!config.type) {
+              config = {
+                name: "${fileBasename}",
+                type: "ocamlearlybird",
+                request: "launch",
+                program: "${file}",
+              };
+            }
+            return config;
+          },
+          async resolveDebugConfigurationWithSubstitutedVariables(
+            folder,
+            config,
+            token
+          ) {
+            if (!(await isBytecodeFile(config.program))) {
+              vscode.window.showErrorMessage(
+                `Expected OCaml bytecode file. ${config.program} is not supported`
+              );
+              return;
+            }
+            return config;
+          },
+        })
+      );
+    } catch (err) {
+      log.error(`failed to activate extension: ${err}`);
+    }
   },
   deactivate() {
     log("deactivated");

--- a/integrations/vscode/extension.js
+++ b/integrations/vscode/extension.js
@@ -3,8 +3,8 @@ const FS = require("fs");
 const Path = require("path");
 
 const EXT_NAME = "ocamlearlybird";
-const MAGIC_LENGTH = SUPPORTED_MAGICS[0].length;
 const SUPPORTED_MAGICS = ["Caml1999X028", "Caml1999X029"];
+const MAGIC_LENGTH = SUPPORTED_MAGICS[0].length;
 
 const log = (() => {
   const logger = vscode.window.createOutputChannel(EXT_NAME);
@@ -87,7 +87,7 @@ module.exports = {
                 yieldSteps: 4096,
                 program: uri.fsPath,
               };
-              log.file(`debug session starting with: ${asJson(options)}`);
+              log.info(`debug session starting with: ${asJson(options)}`);
               await vscode.debug.startDebugging(folder, options);
               log.info("debug session complete");
             } catch (err) {

--- a/integrations/vscode/extension.js
+++ b/integrations/vscode/extension.js
@@ -19,8 +19,11 @@ const log = (() => {
 })();
 
 const isBytecodeFile = async (path) => {
-  const stat = await FS.promises.stat(path);
-  if (!stat.isFile()) return false;
+  const stat = await FS.promises.stat(path).catch((err) => {
+    if (err.code === "ENOENT") return null;
+    throw err;
+  });
+  if (!stat || !stat.isFile()) return false;
   const file = await FS.promises.open(path);
   try {
     const buffer = Buffer.alloc(MAGIC_LENGTH);
@@ -84,9 +87,7 @@ module.exports = {
                 yieldSteps: 4096,
                 program: uri.fsPath,
               };
-              log.file(
-                `debug session starting with: ${asJson(options)}`
-              );
+              log.file(`debug session starting with: ${asJson(options)}`);
               await vscode.debug.startDebugging(folder, options);
               log.info("debug session complete");
             } catch (err) {

--- a/integrations/vscode/extension.js
+++ b/integrations/vscode/extension.js
@@ -1,12 +1,19 @@
-const vscode = require('vscode');
-const FS = require('fs');
-const Path = require('path');
-const CP = require('child_process');
-const Util = require('util');
+const vscode = require("vscode");
+const FS = require("fs");
+const Path = require("path");
+const CP = require("child_process");
+const Util = require("util");
 
-const SUPPORTED_MAGICS = ['Caml1999X028', 'Caml1999X029'];
+const SUPPORTED_MAGICS = ["Caml1999X028", "Caml1999X029"];
 const MAGIC_LENGTH = SUPPORTED_MAGICS[0].length;
 
+const log = (() => {
+  const logger = vscode.window.createOutputChannel();
+  return (text) => {
+    logger.appendLine(text);
+    logger.show();
+  };
+})();
 
 const isBytecodeFile = async (path) => {
   try {
@@ -15,7 +22,7 @@ const isBytecodeFile = async (path) => {
     try {
       const buffer = Buffer.alloc(MAGIC_LENGTH);
       await file.read(buffer, 0, MAGIC_LENGTH, stat.size - MAGIC_LENGTH);
-      const magic = buffer.toString('ascii');
+      const magic = buffer.toString("ascii");
       return SUPPORTED_MAGICS.includes(magic);
     } finally {
       file.close();
@@ -27,74 +34,114 @@ const isBytecodeFile = async (path) => {
 
 const debugConfigProvider = {
   async provideDebugConfigurations(folder, token) {
-    return [{
-      name: 'OCaml Debug',
-      type: 'ocamlearlybird',
-      request: 'launch',
-      program: '${workspaceFolder}/a.out',
-      stopOnEntry: false,
-      yieldSteps: 4096,
-      onlyDebugGlob: "<${workspaceFolder}/**/*>"
-    }];
+    return [
+      {
+        name: "OCaml Debug",
+        type: "ocamlearlybird",
+        request: "launch",
+        program: "${workspaceFolder}/a.out",
+        stopOnEntry: false,
+        yieldSteps: 4096,
+        onlyDebugGlob: "<${workspaceFolder}/**/*>",
+      },
+    ];
   },
   async resolveDebugConfiguration(folder, config, token) {
     if (!config.type) {
       config = {
-        name: '${fileBasename}',
-        type: 'ocamlearlybird',
-        request: 'launch',
-        program: '${file}',
+        name: "${fileBasename}",
+        type: "ocamlearlybird",
+        request: "launch",
+        program: "${file}",
       };
     }
     return config;
   },
-  async resolveDebugConfigurationWithSubstitutedVariables(folder, config, token) {
-    if (!await isBytecodeFile(config.program)) {
-      vscode.window.showErrorMessage('Unsupported file format');
+  async resolveDebugConfigurationWithSubstitutedVariables(
+    folder,
+    config,
+    token
+  ) {
+    if (!(await isBytecodeFile(config.program))) {
+      vscode.window.showErrorMessage("Unsupported file format");
       return;
     }
     return config;
-  }
+  },
 };
+
+const jsonStringifyReplacer = (k, v) =>
+  k ? (typeof v === "function" ? `function:${v.name || k}` : "function") : v;
+const jsonStringify = (str) => JSON.stringify(str, jsonStringifyReplacer, 2);
 
 module.exports = {
   /**@param {vscode.ExtensionContext} context */
   activate(context) {
-    const config = vscode.workspace.getConfiguration('ocamlearlybird');
-    const ocamlearlybirdPath = config.get('path');
-    context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('ocamlearlybird', {
-      createDebugAdapterDescriptor(session, executable) {
-        return new vscode.DebugAdapterExecutable(ocamlearlybirdPath, ['debug']);
-      }
-    }));
-    context.subscriptions.push(vscode.commands.registerCommand('ocamlearlybird.startDebug', async (uri) => {
-      const folder = vscode.workspace.getWorkspaceFolder(uri);
-      await vscode.debug.startDebugging(folder, {
-        name: Path.basename(uri.fsPath),
-        type: "ocamlearlybird",
-        request: "launch",
-        stopOnEntry: true,
-        yieldSteps: 4096,
-        program: uri.fsPath,
-      });
-    }));
-    context.subscriptions.push(vscode.commands.registerCommand('ocamlearlybird.variableGotoClosureCodeLocation', async (context) => {
-      const result = await vscode.debug.activeDebugSession.customRequest("variableGetClosureCodeLocation", { handle: context.variable.variablesReference });
-      if (result.location != null) {
-        const loc = result.location;
-        const doc = vscode.workspace.openTextDocument(result.location.source);
-        vscode.window.showTextDocument(doc, {
-          preview: true,
-          selection: new vscode.Range(
-            new vscode.Position(loc.pos[0] - 1, loc.pos[1] - 1),
-            new vscode.Position(loc.end_[0] - 1, loc.end_[1] - 1),
-          ),
+    log(`activating`);
+    const config = vscode.workspace.getConfiguration("ocamlearlybird");
+    const serializedConfig = jsonStringify(config);
+    log(`configuration detected: ${serializedConfig}`);
+    const ocamlearlybirdPath = config.get("path");
+    context.subscriptions.push(
+      vscode.debug.registerDebugAdapterDescriptorFactory("ocamlearlybird", {
+        createDebugAdapterDescriptor(session, executable) {
+          log(`on:createDebugAdapterDescriptor`);
+          return new vscode.DebugAdapterExecutable(ocamlearlybirdPath, [
+            "debug",
+          ]);
+        },
+      })
+    );
+    context.subscriptions.push(
+      vscode.commands.registerCommand("ocamlearlybird.startDebug", async () => {
+        log(`on:ocamlearlybird.startDebug`);
+        const uri = vscode.window.activeTextEditor.document.uri;
+        const folder = vscode.workspace.getWorkspaceFolder();
+        await vscode.debug.startDebugging(folder, {
+          name: Path.basename(uri.fsPath),
+          type: "ocamlearlybird",
+          request: "launch",
+          stopOnEntry: true,
+          yieldSteps: 4096,
+          program: uri.fsPath,
         });
-      } else {
-        vscode.window.showInformationMessage("No closure code location");
-      }
-    }));
-    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('ocamlearlybird', debugConfigProvider));
+      })
+    );
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        "ocamlearlybird.variableGotoClosureCodeLocation",
+        async (context) => {
+          log(`on:ocamlearlybird.variableGotoClosureCodeLocation`);
+          const result = await vscode.debug.activeDebugSession.customRequest(
+            "variableGetClosureCodeLocation",
+            { handle: context.variable.variablesReference }
+          );
+          if (result.location != null) {
+            const loc = result.location;
+            const doc = vscode.workspace.openTextDocument(
+              result.location.source
+            );
+            vscode.window.showTextDocument(doc, {
+              preview: true,
+              selection: new vscode.Range(
+                new vscode.Position(loc.pos[0] - 1, loc.pos[1] - 1),
+                new vscode.Position(loc.end_[0] - 1, loc.end_[1] - 1)
+              ),
+            });
+          } else {
+            vscode.window.showInformationMessage("No closure code location");
+          }
+        }
+      )
+    );
+    context.subscriptions.push(
+      vscode.debug.registerDebugConfigurationProvider(
+        "ocamlearlybird",
+        debugConfigProvider
+      )
+    );
   },
-  deactivate() { }
+  deactivate() {
+    log("deactivated");
+  },
 };

--- a/integrations/vscode/package-lock.json
+++ b/integrations/vscode/package-lock.json
@@ -1,8 +1,46 @@
 {
   "name": "ocamlearlybird",
   "version": "1.2.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "ocamlearlybird",
+      "version": "1.2.0",
+      "devDependencies": {
+        "@types/node": "^14.14.22",
+        "@types/vscode": "^1.54.0",
+        "prettier": "2.4.1"
+      },
+      "engines": {
+        "vscode": "^1.54.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "14.14.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
+      "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==",
+      "dev": true
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.54.0.tgz",
+      "integrity": "sha512-sHHw9HG4bTrnKhLGgmEiOS88OLO/2RQytUN4COX9Djv81zc0FSZsSiYaVyjNidDzUSpXsySKBkZ31lk2/FbdCg==",
+      "dev": true
+    },
+    "node_modules/prettier": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    }
+  },
   "dependencies": {
     "@types/node": {
       "version": "14.14.22",
@@ -14,6 +52,12 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.54.0.tgz",
       "integrity": "sha512-sHHw9HG4bTrnKhLGgmEiOS88OLO/2RQytUN4COX9Djv81zc0FSZsSiYaVyjNidDzUSpXsySKBkZ31lk2/FbdCg==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "dev": true
     }
   }

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -71,6 +71,11 @@
             "type": "string",
             "description": "Path to ocamlearlybird executable.",
             "default": "ocamlearlybird"
+          },
+          "ocamlearlybird.connectToLocalDebugAdapterServer": {
+            "type": "boolean",
+            "description": "Connect to a running ocamlearlybird server.",
+            "default": false
           }
         }
       }
@@ -165,6 +170,10 @@
   },
   "devDependencies": {
     "@types/node": "^14.14.22",
-    "@types/vscode": "^1.54.0"
+    "@types/vscode": "^1.54.0",
+    "prettier": "2.4.1"
+  },
+  "scripts": {
+    "format": "prettier . --write"
   }
 }


### PR DESCRIPTION
# problem

- no extension logging
  - i have more than one issue getting the debugger working. having logging in place really helped me narrow down where debug launch issues where originating
- the bytecode detection logic was ok, but i noticed it was possibly swallowing errors and simply returning `false` if any logic failed within the `try {}` block
- during debugging, I could not see output from `ocamlearlybird`, as it's a VSCode managed process, but I had suspicion it may be crashing

# solution

- use the vscode extension logging provider

![image](https://user-images.githubusercontent.com/1003261/139563970-2a165d30-0212-4b51-8eed-237c4f0bb2ea.png)

- improve error handling case
- add a configuration setting, `"ocamlearlybird.connectToLocalDebugAdapterServer"`, which simply as implemented, just connects to `earlybird` on `localhost:4417`, vs launching an instance from VSCode for DAP. This helped me identify #36 ..., which really was two problems, the primary one being my copy of `jsoo` segfaulting 😆 
- ...and 😬 😬 😬 , I accidentally ran [prettier](https://www.npmjs.com/package/prettier) on VSCode project. In case you are not aware, `prettier` is the `ocamlformat` of JS. I am willing to undo the prettier format, but there is not an explicit style guide or formatter listed for the JS. Much like OCaml is all in on `ocamlformat`, so too do i like to "never discuss" formatting in changesets. Given that I did it and it's just a single file, I added prettier to devDeps in case you are interested in adopting it? Let me know