### PR TITLE
Enabled macOS in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "GA"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    commit-message:
-      prefix: "GA"
-      include: "scope"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,14 @@ name: ci
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
   workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * *"
 
 jobs:
   build:
@@ -13,7 +19,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          # - macos-latest
+          - macos-latest
         ocaml-compiler:
           - 5.2.x
           - 5.1.x


### PR DESCRIPTION
Adds dependabot to check GH Action updates and updates triggers so it only runs a single build per target per PR.