### PR TITLE
remove gif from repo

### DIFF
--- a/_assets/ocamlearlybird-debugging-utop-demo.gif
+++ b/_assets/ocamlearlybird-debugging-utop-demo.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2672d31777979316948f5b2465a681446954a6ec56a04ac3350809f14cddb493
-size 19206868


### PR DESCRIPTION
Resolve git lfs out of quota issue.

<img width="746" alt="WeChatWorkScreenshot_b436dbe2-e648-4b14-9f38-1b0f743862fa" src="https://github.com/user-attachments/assets/a70ba3ec-c1dc-4e06-ad3d-4e906378a3c7">
