### PR TITLE
Extend Instruct.compilation_env heap support to OCaml 4.14.3+

### DIFF
--- a/src/debugger/inspect/eval.ml
+++ b/src/debugger/inspect/eval.ml
@@ -1,6 +1,6 @@
 open Ground
 
-[%%if ocaml_version >= (5, 2, 0)]
+[%%if ocaml_version >= (5, 2, 0) || (ocaml_version >= (4, 14, 3) && ocaml_version < (5, 0, 0))]
 let ident_find_same_heap id (compenv: Instruct.compilation_env) =
   match compenv.ce_closure with
   | Not_in_closure -> raise Not_found

--- a/src/debugger/inspect/value_scope.ml
+++ b/src/debugger/inspect/value_scope.ml
@@ -11,7 +11,7 @@ class virtual scope_value =
     method! num_named = -1
   end
 
-[%%if ocaml_version >= (5, 2, 0)]
+[%%if ocaml_version >= (5, 2, 0) || (ocaml_version >= (4, 14, 3) && ocaml_version < (5, 0, 0))]
 let iter_compenv_heap f (compenv: Instruct.compilation_env) =
   match compenv.ce_closure with
   | Not_in_closure -> ()


### PR DESCRIPTION
The upstream changes in https://github.com/ocaml/ocaml/pull/12222 (originally for OCaml 5.2) have been backported to the 4.14 branch via https://github.com/ocaml/ocaml/pull/13204 and officially released in OCaml 4.14.3.

This PR adapts the conditional compilation guards to enable the new heap support for these versions.

Version Coverage:

* 4.14.3+: Supported (due to backport)
* 5.0.x / 5.1.x: Not supported (upstream changes only landed in 5.2+)
* 5.2.0+: Supported

References:
* OCaml 4.14.3 Release Notes: https://discuss.ocaml.org/t/ocaml-5-4-1-and-4-14-3-released/17822
* Related issue: https://github.com/hackwaly/ocamlearlybird/issues/60